### PR TITLE
 MFP2-1913: Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @metacollin @gpisacco @nalundgaard


### PR DESCRIPTION
Ticket: https://macrofab.atlassian.net/browse/MFP2-1913

I think we should probably archive this repo, but it's still in use in a couple of places. I don't really want to apply any linting to it, since it's a public repo fork that needs to die, but here is an owners update.